### PR TITLE
Do not cast annotation values with str

### DIFF
--- a/spoqa_aws_xray_flask_middleware.py
+++ b/spoqa_aws_xray_flask_middleware.py
@@ -27,5 +27,5 @@ class XRayMiddleware(OrigMiddleware):
             path = req.path
         url = urlparse.urljoin('//{}/'.format(segment.name), path)
 
-        segment.put_http_meta(http.URL, str(url))
-        segment.put_annotation(http.URL, str(req.base_url))
+        segment.put_http_meta(http.URL, url)
+        segment.put_annotation(http.URL, req.base_url)


### PR DESCRIPTION
If the annotation values contain unicode, it raises an error in Python 2.

Originally, I explicitly cast the value with str because the SDK did not allow and ignore values of unicode type (https://github.com/aws/aws-xray-sdk-python/blob/aed8e43fc03e68c0d012a6a6e11a2e859b0bf247/aws_xray_sdk/core/utils/compat.py#L9)

This problem will be fixed with direct PR (https://github.com/aws/aws-xray-sdk-python/pull/235) to the aws-xray-sdk.