### PR TITLE
Append `SCRIPT_NAME` environment to URL for nested applications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,79 @@
+version: 2.1
+
+jobs:
+  test-py27:
+    docker:
+    - image: circleci/python:2.7
+    environment:
+      PYTHON_VERSION: "2.7"
+    working_directory: ~/repo
+    steps: &test-steps
+    - run:
+        name: Install poetry
+        command: |
+          curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py > get-poetry.py
+          python get-poetry.py --yes --version 1.0.9
+          rm -f get-poetry.py
+          echo 'export PATH="$HOME/.poetry/bin:$PATH"' >> $BASH_ENV
+    - checkout
+    - restore_cache:
+        keys:
+        - test-v1-{{ .Environment.PYTHON_VERSION }}-{{ checksum "pyproject.toml" }}-
+        - test-v1-{{ .Environment.PYTHON_VERSION }}-
+    - run:
+        name: Install dependencies
+        command: |
+          python -m virtualenv venv
+          . venv/bin/activate
+          poetry install
+    - save_cache:
+        key: test-v1-{{ .Environment.PYTHON_VERSION }}-{{ checksum "pyproject.toml" }}-{{ epoch }}
+        paths:
+        - ./venv
+    - run:
+        name: Test
+        command: |
+          . venv/bin/activate
+          pytest -vv tests
+
+  test-py35:
+    docker:
+    - image: circleci/python:3.5
+    environment:
+      PYTHON_VERSION: "3.5"
+    working_directory: ~/repo
+    steps: *test-steps
+
+  test-py36:
+    docker:
+    - image: circleci/python:3.6
+    environment:
+      PYTHON_VERSION: "3.6"
+    working_directory: ~/repo
+    steps: *test-steps
+
+  test-py37:
+    docker:
+    - image: circleci/python:3.7
+    environment:
+      PYTHON_VERSION: "3.7"
+    working_directory: ~/repo
+    steps: *test-steps
+
+  test-py38:
+    docker:
+    - image: circleci/python:3.8
+    environment:
+      PYTHON_VERSION: "3.8"
+    working_directory: ~/repo
+    steps: *test-steps
+
+workflows:
+  version: 2
+  test:
+    jobs:
+    - test-py27
+    - test-py35
+    - test-py36
+    - test-py37
+    - test-py38

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 exclude = .env, .tox, docs
 import-order-style = spoqa
+application-import-names = spoqa_aws_xray_flask_middleware, tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ flake8 = "^3.8.3"
 flake8-import-order-spoqa = "^1.5.0"
 pytest = "^4.6"
 pytest-flake8 = "^1.0.6"
+werkzeug = "^1.0.1"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,10 @@ repository = "https://github.com/spoqa/aws-xray-flask-middleware"
 
 [tool.poetry.dependencies]
 python = "^2.7 | ^3.5"
-aws-xray-sdk = "^2.6.0"
+# aws-xray-sdk = "^2.6.0"
+# FIXME
+# https://github.com/aws/aws-xray-sdk-python/pull/235
+aws-xray-sdk = { git = "https://github.com/spoqa/aws-xray-sdk-python.git", branch = "unicode-annotation-values" }
 flask = ">=0.10"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ flask = ">=0.10"
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.3"
 flake8-import-order-spoqa = "^1.5.0"
+pytest = "^4.6"
+pytest-flake8 = "^1.0.6"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+addopts = --ff --flake8
+flake8-max-line-length = 79
+flake8-ignore =
+    docs/*.py ALL
+    .env ALL
+    .venv ALL

--- a/spoqa_aws_xray_flask_middleware.py
+++ b/spoqa_aws_xray_flask_middleware.py
@@ -22,7 +22,8 @@ class XRayMiddleware(OrigMiddleware):
             segment = self._recorder.current_segment()
 
         if req.url_rule:
-            path = req.url_rule.rule
+            script_name = req.environ.get('SCRIPT_NAME', '')
+            path = script_name + req.url_rule.rule
         else:
             path = req.path
         url = urlparse.urljoin('//{}/'.format(segment.name), path)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from aws_xray_sdk import global_sdk_config
 from aws_xray_sdk.core.context import Context
 from flask import Flask

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,66 @@
+from aws_xray_sdk import global_sdk_config
+from aws_xray_sdk.core.context import Context
+from flask import Flask
+from pytest import fixture, yield_fixture
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
+
+from spoqa_aws_xray_flask_middleware import XRayMiddleware
+from tests.util import get_new_stubbed_recorder
+
+
+@yield_fixture
+def fx_recorder():
+    recorder = get_new_stubbed_recorder()
+    recorder.configure(service='test', sampling=False, context=Context())
+    recorder.clear_trace_entities()
+    yield recorder
+    recorder.clear_trace_entities()
+    global_sdk_config.set_sdk_enabled(True)
+
+
+@fixture
+def fx_second_flask_app():
+    app = Flask(__name__)
+
+    @app.route('/ping')
+    def ping():
+        return 'pong'
+
+    @app.route('/bye/<string:name>')
+    def bye(name):
+        return 'Bye, {}'.format(name)
+    app.config['TESTING'] = True
+
+    return app
+
+
+@fixture
+def fx_flask_app(fx_second_flask_app):
+    app = Flask(__name__)
+
+    @app.route('/ok')
+    def ok():
+        return 'ok'
+
+    @app.route('/hello/<string:name>')
+    def hello(name):
+        return 'Hello, {}'.format(name)
+
+    app.wsgi_app = DispatcherMiddleware(
+        app.wsgi_app,
+        {'/nested': fx_second_flask_app},
+    )
+    app.config['TESTING'] = True
+
+    return app
+
+
+@fixture
+def fx_flask_app_with_middleware(
+    fx_recorder,
+    fx_flask_app,
+    fx_second_flask_app,
+):
+    XRayMiddleware(fx_flask_app, fx_recorder)
+    XRayMiddleware(fx_second_flask_app, fx_recorder)
+    return fx_flask_app

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,78 @@
+def test_ok(fx_flask_app_with_middleware, fx_recorder):
+    client = fx_flask_app_with_middleware.test_client()
+
+    client.get('/ok')
+
+    segment = fx_recorder.emitter.pop()
+    assert not segment.in_progress
+
+    request = segment.http['request']
+    response = segment.http['response']
+    annotation = segment.annotations
+
+    assert request['method'] == 'GET'
+    assert request['url'] == '//test/ok'
+    assert request['client_ip'] == '127.0.0.1'
+    assert response['status'] == 200
+    assert response['content_length'] == 2
+    assert annotation['url'] == 'http://localhost/ok'
+
+
+def test_hello(fx_flask_app_with_middleware, fx_recorder):
+    client = fx_flask_app_with_middleware.test_client()
+
+    client.get('/hello/xray')
+
+    segment = fx_recorder.emitter.pop()
+    assert not segment.in_progress
+
+    request = segment.http['request']
+    response = segment.http['response']
+    annotation = segment.annotations
+
+    assert request['method'] == 'GET'
+    assert request['url'] == '//test/hello/<string:name>'
+    assert request['client_ip'] == '127.0.0.1'
+    assert response['status'] == 200
+    assert response['content_length'] == 11
+    assert annotation['url'] == 'http://localhost/hello/xray'
+
+
+def test_nested_ping(fx_flask_app_with_middleware, fx_recorder):
+    client = fx_flask_app_with_middleware.test_client()
+
+    client.get('/nested/ping')
+
+    segment = fx_recorder.emitter.pop()
+    assert not segment.in_progress
+
+    request = segment.http['request']
+    response = segment.http['response']
+    annotation = segment.annotations
+
+    assert request['method'] == 'GET'
+    assert request['url'] == '//test/nested/ping'
+    assert request['client_ip'] == '127.0.0.1'
+    assert response['status'] == 200
+    assert response['content_length'] == 4
+    assert annotation['url'] == 'http://localhost/nested/ping'
+
+
+def test_nested_bye(fx_flask_app_with_middleware, fx_recorder):
+    client = fx_flask_app_with_middleware.test_client()
+
+    client.get('/nested/bye/xray')
+
+    segment = fx_recorder.emitter.pop()
+    assert not segment.in_progress
+
+    request = segment.http['request']
+    response = segment.http['response']
+    annotation = segment.annotations
+
+    assert request['method'] == 'GET'
+    assert request['url'] == '//test/nested/bye/<string:name>'
+    assert request['client_ip'] == '127.0.0.1'
+    assert response['status'] == 200
+    assert response['content_length'] == 9
+    assert annotation['url'] == 'http://localhost/nested/bye/xray'

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,48 @@
+# Reference:
+# https://github.com/aws/aws-xray-sdk-python/blob/aed8e43fc03e68c0d012a6a6e11a2e859b0bf247/tests/util.py
+
+import threading
+
+from aws_xray_sdk.core.emitters.udp_emitter import UDPEmitter
+from aws_xray_sdk.core.recorder import AWSXRayRecorder
+from aws_xray_sdk.core.sampling.sampler import DefaultSampler
+from aws_xray_sdk.core.utils.compat import PY35
+
+
+class StubbedEmitter(UDPEmitter):
+
+    def __init__(self, daemon_address='127.0.0.1:2000'):
+        super(StubbedEmitter, self).__init__(daemon_address)
+        self._local = threading.local()
+
+    def send_entity(self, entity):
+        setattr(self._local, 'cache', entity)
+
+    def pop(self):
+        if hasattr(self._local, 'cache'):
+            entity = self._local.cache
+        else:
+            entity = None
+
+        self._local.__dict__.clear()
+        return entity
+
+
+class StubbedSampler(DefaultSampler):
+
+    def start(self):
+        pass
+
+
+def get_new_stubbed_recorder():
+    """
+    Returns a new AWSXRayRecorder object with emitter stubbed
+    """
+    if not PY35:
+        recorder = AWSXRayRecorder()
+    else:
+        from aws_xray_sdk.core.async_recorder import AsyncAWSXRayRecorder
+        recorder = AsyncAWSXRayRecorder()
+
+    recorder.configure(emitter=StubbedEmitter(), sampler=StubbedSampler())
+    return recorder


### PR DESCRIPTION
This middleware's key feature is that the middleware construct `url` with `url_rule`, not `base_url`. But if the application was nested with the werkzeug's DispatcherMiddleware (https://werkzeug.palletsprojects.com/en/1.0.x/middleware/dispatcher/), the `url_rule` of request does not match with the real URL. So I append `SCRIPT_NAME` from werkzeug request environment at the beginning of `url_rule`.

- Append `SCRIPT_NAME` from werkzeug environment for nested WSGI applications with DispatcherMiddleware.
- Add tests and CI to assure everything works well.